### PR TITLE
Fixed !__has_feature(objc_arc) issue (typo?)

### DIFF
--- a/CaptainHook.h
+++ b/CaptainHook.h
@@ -14,7 +14,7 @@
 #endif
 
 #ifdef __clang__
-#if !__has_feature(objc_arc)
+#if __has_feature(objc_arc)
 #define CHHasARC
 #endif
 #endif


### PR DESCRIPTION
This seems a typo to me: you are checking if the compiler doesn't support ARC to define CHHasARC.
This way Xcode doesn't compile giving ARC-related errors, but removing the negation (!) fixes all of them.

Also, may I suggest you to follow the advice from Clang (http://bit.ly/Jt5XKj) of checking if __has_feature is defined instead of checking if __clang__ is defined. :)
